### PR TITLE
Create default config

### DIFF
--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -13,7 +13,13 @@
     
     // Load the menu content
     // [self loadMenu];
-
+    
+    // if the config file does not exist, create a default one
+    if ( ![[NSFileManager defaultManager] fileExistsAtPath:shuttleConfigFile] ) {
+        NSString *cgFileInResource = [[NSBundle mainBundle] pathForResource:@"shuttle.default" ofType:@"json"];
+        [[NSFileManager defaultManager] copyItemAtPath:cgFileInResource toPath:shuttleConfigFile error:nil];
+    }
+    
     // Create the status bar item
     statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:25.0];
     [statusItem setMenu:menu];
@@ -139,12 +145,6 @@
     NSUInteger n = [[menu itemArray] count];
     for (int i=0;i<n-4;i++) {
         [menu removeItemAtIndex:0];
-    }
-
-    // if the config file does not exist, create a default one
-    if ( ![[NSFileManager defaultManager] fileExistsAtPath:shuttleConfigFile] ) {
-        NSString *cgFileInResource = [[NSBundle mainBundle] pathForResource:@"shuttle.default" ofType:@"json"];
-        [[NSFileManager defaultManager] copyItemAtPath:cgFileInResource toPath:shuttleConfigFile error:nil];
     }
     
     // Parse the config file


### PR DESCRIPTION
Moved the default config creation to awakeFromNib, because if neither
ssh_config nor config exist, it never get's created
