### PR TITLE
Added iterm_profile config. Also fixed a problem when iTerm2 is running but has no terminals.

### DIFF
--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -12,6 +12,7 @@
 
     NSStatusItem *statusItem;
     NSString *shuttleConfigFile;
+    NSString *itermProfile;
     
     // This is for the JSON File
     NSDate *configModified;


### PR DESCRIPTION
I wanted to be able to set the iTerm2 profile that Shuttle uses when launching ssh sessions. For now, it's a global config. I wanted to go a step further and allow the user to set the profile for each menu item individually but that appears to be a much bigger code change.

Also, there was a problem where if iTerm2 is in a state where it is running but has no open terminals (i.e. the user closed all the iTerm2 windows), Shuttle would not be able to launch a session. I fixed that in the AppleScript by detecting the no-terminal condition and making a new terminal.

