### PR TITLE
Update shuttle.default.json

### DIFF
--- a/Shuttle/shuttle.default.json
+++ b/Shuttle/shuttle.default.json
@@ -1,7 +1,9 @@
 {
-	"_comment1": "Valid terminals include: 'Terminal.app' or 'iTerm'",
-	"_comment2": "Hosts will also be read from your ~/.ssh/config or /etc/ssh_config file, if available",
-	"_comment3": "For more information on how to configure, please see http://fitztrev.github.io/shuttle/",
+	"_comments": [
+		"Valid terminals include: 'Terminal.app' or 'iTerm'",
+		"Hosts will also be read from your ~/.ssh/config or /etc/ssh_config file, if available",
+		"For more information on how to configure, please see http://fitztrev.github.io/shuttle/"
+	],
 	"terminal": "Terminal.app",
 	"launch_at_login": false,
 	"show_ssh_config_hosts": true,


### PR DESCRIPTION
comments are now stored in an array to not clobber the key space.
