### PR TITLE
Remove the status icon from the status bar on quit.

### DIFF
--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -352,7 +352,7 @@
 }
 
 - (IBAction)quit:(id)sender {
-	[[NSStatusBar systemStatusBar] removeStatusItem:statusItem];
+    [[NSStatusBar systemStatusBar] removeStatusItem:statusItem];
     [NSApp terminate:NSApp];
 }
 


### PR DESCRIPTION
This fix will make sure there is no blank-space left in your status bar when you quit the program.
