### PR TITLE
Add nested menus (and other stuff)

### DIFF
--- a/Shuttle/shuttle.default.json
+++ b/Shuttle/shuttle.default.json
@@ -17,6 +17,13 @@
 				 {
 					 "name": "My blog",
 					 "cmd": "ssh username@blog.example.com"
+				 },
+				 {
+					 "Spouse": [
+						 {
+							 "name": "Her blog",
+							 "cmd": "ssh username@blog2.example.com"
+						 }
 				 }
 			 ]
 		},


### PR DESCRIPTION
It is now possible to have menus within menus. The nesting depth is not restricted (except for memory and useability).

Configuration support has been added for JSON and ssh/config configurations.

JSON configurations simply nest the host entries as deep as required.

For the ssh/config configuration the Host name can now have multiple '/' separators. The name is splitted among the separator, resulting in the menu levels. The last level corresponds to the name of the final menu entry for the actual connection.

However you can now also configure more data into the ssh/config file. It is possible to add key/value pairs within a Host section using comments:

<pre>
Host work/servers/gandalf
HostName gandalf@example.com
</pre>


could also be written as:

<pre>
Host gandalf
# shuttle.name = work/servers/gandalf (webserver)
HostName gandalf@example.com
</pre>


The resulting menustructure would then be

<pre>
work -> servers -> gandalf (webserver)
</pre>


Currently shuttle.name is the only supported key/value pair.
