### PR TITLE
Added support for macros

### DIFF
--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -20,6 +20,7 @@
     
     NSString *terminalPref;
     NSMutableArray* shuttleHosts;
+    NSMutableArray* shuttleMacros;
     NSMutableArray* ignoreHosts;
     NSMutableArray* ignoreKeywords;
     


### PR DESCRIPTION
Adding \_macro\_ to the name of a menu item will run the command in the same terminal window. After sshing to a server I often use the same series of commands. I can now add these commands to the menu as macros.

Created a string called selectedItem that holds the title name.

In (void) openHost added some logic that checks to see if the title contains the string "\_macro\_" if \_macro\_ exists then the applescript opens Terminal.app or iTerm and executes the command in the last used tab or window. 

added "reopen" to the applescript code so that the minimized terminal will be used.  

Example:
"name": "ssh processes --- \_macro\_",
"cmd": "ps aux | grep [s]sh"