### PR TITLE
Added Yosemite OSX Dark Mode menu icon support.

### DIFF
--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -10,6 +10,9 @@
     IBOutlet NSMenu *menu;
     IBOutlet NSArrayController *arrayController;
 
+    NSImage *regularIcon;
+    NSImage *altIcon;
+    
     NSStatusItem *statusItem;
     NSString *shuttleConfigFile;
     

--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -19,13 +19,28 @@
 
     // Load the menu content
     // [self loadMenu];
+
+    // Define Icons
+    regularIcon = [NSImage imageNamed:@"StatusIcon"];
+    altIcon = [NSImage imageNamed:@"StatusIconAlt"];
+    
+    // Check for AppKit Version, add support for darkmode if > 10.9
+    BOOL oldAppKitVersion = (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_9);
+    
+    if (!oldAppKitVersion)
+    {
+        // 10.10 or higher, add support to icon for auto detection of Regular/Dark mode
+        [regularIcon setTemplate:YES];
+        [altIcon setTemplate:YES];
+    }
     
     // Create the status bar item
     statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:25.0];
+    
     [statusItem setMenu:menu];
     [statusItem setHighlightMode:YES];
-    [statusItem setImage:[NSImage imageNamed:@"StatusIcon"]];
-    [statusItem setAlternateImage:[NSImage imageNamed:@"StatusIconAlt"]];
+    [statusItem setImage: regularIcon];
+    [statusItem setAlternateImage: altIcon];
 
     launchAtLoginController = [[LaunchAtLoginController alloc] init];
     


### PR DESCRIPTION
Added 10.10 dark mode icon support:

![darkmodeicon2](https://cloud.githubusercontent.com/assets/4718238/4774431/3d735ea2-5bad-11e4-862d-5d6b82d3bc57.png)
