### PR TITLE
JSON Settings editor option

### DIFF
--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -22,6 +22,7 @@
     NSDate *sshConfigSystem;
     
     NSString *terminalPref;
+    NSString *editorPref;
     NSMutableArray* shuttleHosts;
     NSMutableArray* ignoreHosts;
     NSMutableArray* ignoreKeywords;

--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -182,6 +182,7 @@
     }
     
     terminalPref = [json[@"terminal"] lowercaseString];
+    editorPref = [json[@"editor"] lowercaseString];
     launchAtLoginController.launchAtLogin = [json[@"launch_at_login"] boolValue];
     shuttleHosts = json[@"hosts"];
     ignoreHosts = json[@"ssh_config_ignore_hosts"];
@@ -438,8 +439,27 @@
 
 
 - (IBAction)configure:(id)sender {
-    [[NSWorkspace sharedWorkspace] openFile:shuttleConfigFile];
+    
+    //if the editor setting is omitted or contains 'default' open using the default editor.
+    if([editorPref rangeOfString:@"default"].location != NSNotFound) {
+        
+        [[NSWorkspace sharedWorkspace] openFile:shuttleConfigFile];
+    }
+    else{
+        //build the editor command
+        NSString *editorCommand = [NSString stringWithFormat:@"%@ %@", editorPref, shuttleConfigFile];
+        
+        //make a menu item for the command selector(openHost:) runs in a new terminal window.
+        NSMenuItem *editorMenu = [[NSMenuItem alloc] initWithTitle:@"editJSONconfig" action:@selector(openHost:) keyEquivalent:(@"")];
+        
+        //set the command for the menu item
+        [editorMenu setRepresentedObject:editorCommand];
+        
+        //open the JSON file in the terminal editor.
+        [self openHost:editorMenu];
+    }
 }
+
 
 - (IBAction)showAbout:(id)sender {
     [[NSWorkspace sharedWorkspace] openURL: [NSURL URLWithString:@"http://fitztrev.github.io/shuttle"]];

--- a/Shuttle/shuttle.default.json
+++ b/Shuttle/shuttle.default.json
@@ -1,58 +1,60 @@
 {
-	"_comments": [
-		"Valid terminals include: 'Terminal.app' or 'iTerm'",
-		"Hosts will also be read from your ~/.ssh/config or /etc/ssh_config file, if available",
-		"For more information on how to configure, please see http://fitztrev.github.io/shuttle/"
-	],
-	"terminal": "Terminal.app",
-	"launch_at_login": false,
-	"show_ssh_config_hosts": true,
-	"ssh_config_ignore_hosts": [],
-	"ssh_config_ignore_keywords": [],
-	"hosts": [
-		{
-			"name": "My Dev Server",
-			"cmd": "ssh username@dev.example.com"
-		},
-		{
-			"Personal": [
-				{
-					"name": "My blog",
-					"cmd": "ssh username@blog.example.com"
-				},
-				{
-					"Spouse": [
-						{
-							"name": "Her blog",
-							"cmd": "ssh username@blog2.example.com"
-						}
-					]
-				}
-			]
-		},
-		{
-			"Work": [
-				{
-					"name": "dev.example.net",
-					"cmd": "ssh username@dev.example.net -p 3000"
-				},
-				{
-					"name": "staging.example.net",
-					"cmd": "ssh username@staging.example.net -p 3000"
-				},
-				{
-					"name": "production.example.net",
-					"cmd": "ssh username@example.net -p 3000"
-				}
-			]
-		},
-		{
-			"Vagrant": [
-				{
-					"name": "precise32",
-					"cmd": "ssh vagrant@127.0.0.1 -p 2222 -i ~/.vagrant.d/insecure_private_key"
-				}
-			]
-		}
-	]
+    "_comments": [
+                  "Valid terminals include: 'Terminal.app' or 'iTerm'",
+                  "In the editor value change 'default' to 'nano', 'vi', or another terminal based editor.",
+                  "Hosts will also be read from your ~/.ssh/config or /etc/ssh_config file, if available",
+                  "For more information on how to configure, please see http://fitztrev.github.io/shuttle/"
+                  ],
+    "terminal": "Terminal.app",
+    "editor": "default",
+    "launch_at_login": false,
+    "show_ssh_config_hosts": true,
+    "ssh_config_ignore_hosts": [],
+    "ssh_config_ignore_keywords": [],
+    "hosts": [
+              {
+              "name": "My Dev Server",
+              "cmd": "ssh username@dev.example.com"
+              },
+              {
+              "Personal": [
+                           {
+                           "name": "My blog",
+                           "cmd": "ssh username@blog.example.com"
+                           },
+                           {
+                           "Spouse": [
+                                      {
+                                      "name": "Her blog",
+                                      "cmd": "ssh username@blog2.example.com"
+                                      }
+                                      ]
+                           }
+                           ]
+              },
+              {
+              "Work": [
+                       {
+                       "name": "dev.example.net",
+                       "cmd": "ssh username@dev.example.net -p 3000"
+                       },
+                       {
+                       "name": "staging.example.net",
+                       "cmd": "ssh username@staging.example.net -p 3000"
+                       },
+                       {
+                       "name": "production.example.net",
+                       "cmd": "ssh username@example.net -p 3000"
+                       }
+                       ]
+              },
+              {
+              "Vagrant": [
+                          {
+                          "name": "precise32",
+                          "cmd": "ssh vagrant@127.0.0.1 -p 2222 -i ~/.vagrant.d/insecure_private_key"
+                          }
+                          ]
+              }
+              ]
 }


### PR DESCRIPTION
In the JSON settings file modifying the new option “editor”: “default”,
will open the settings file from the Settings > edit menu in that
editor.

Set the editor to 'nano', 'vi', or any terminal based editor. Delete
the editor line or keep it 'default' to use your systems default editor