### PR TITLE
specify custom path to the json file

### DIFF
--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -15,6 +15,7 @@
     
     NSStatusItem *statusItem;
     NSString *shuttleConfigFile;
+    NSString *shuttleFilePath;
     
     // This is for the JSON File
     NSDate *configModified;

--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -8,13 +8,27 @@
 @implementation AppDelegate
 
 - (void) awakeFromNib {
+    
+    // The location for the path file. This is a simple file that contains the hard path to the *.json.
+    shuttleFilePath = [NSHomeDirectory() stringByAppendingPathComponent:@".shuttle.path"];
+    
+    //if file shuttle.path exists in ~/.shuttle.path then read this file as it should contain the custom path to *.json
+    if( [[NSFileManager defaultManager] fileExistsAtPath:shuttleFilePath] ) {
+        //Read the shuttle.path file which contains the path to the json file
+        NSString *jsonConfigPath = [NSString stringWithContentsOfFile:shuttleFilePath encoding:NSUTF8StringEncoding error:NULL];
+        //Remove the white space if any.
+        jsonConfigPath = [ jsonConfigPath stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        //set the custom path.
+        shuttleConfigFile = jsonConfigPath;
+    }   else {
     // The path for the configuration file (by default: ~/.shuttle.json)
     shuttleConfigFile = [NSHomeDirectory() stringByAppendingPathComponent:@".shuttle.json"];
-    
+        
     // if the config file does not exist, create a default one
     if ( ![[NSFileManager defaultManager] fileExistsAtPath:shuttleConfigFile] ) {
         NSString *cgFileInResource = [[NSBundle mainBundle] pathForResource:@"shuttle.default" ofType:@"json"];
         [[NSFileManager defaultManager] copyItemAtPath:cgFileInResource toPath:shuttleConfigFile error:nil];
+        }
     }
 
     // Load the menu content


### PR DESCRIPTION
The ability to store the json file in a custom path is useful
especially if your using the same json file on several systems through
a service like dropbox, one drive, box etc…
These changes allow you set a hard coded path to the *.json file. To do
this you would create a new file in your home directory called
.shuttle.path so ~/.shuttle.path would be the name and location.
In this file is the path to the json file. Mine currently reads
/Users/thshdw/Desktop/shuttle.json

if the shuttle.path file does not exist then the system reads the json file
in its default location ~/.shuttle.json. This ensures that these changes are backwards compatible with existing installs.