### PR TITLE
Add ability to specify an iTerm profile per connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ A simple SSH shortcut menu for OS X
 
 The default, out-of-the-box configuration should be good enough to get started. However, if you're looking to customize the appearance further, here are a few advanced tips.
 
+### Use a specific iTerm profile for a connection
+
+```
+"profile": "iTerm Profile Name"
+```
+
 ### Disabling `~/.ssh/config` hosts
 
 By default, Shuttle will parse your `~/.ssh/config` file for hosts.

--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -332,7 +332,7 @@
         NSDictionary* cfg = leafs[key];
         NSMenuItem* menuItem = [[NSMenuItem alloc] init];
         [menuItem setTitle:cfg[@"name"]];
-        [menuItem setRepresentedObject:cfg[@"cmd"]];
+        [menuItem setRepresentedObject:cfg];
         [menuItem setAction:@selector(openHost:)];
         [m insertItem:menuItem atIndex:pos++];
     }
@@ -342,10 +342,14 @@
     //NSLog(@"sender: %@", sender);
     //NSLog(@"Command: %@",[sender representedObject]);
     
-    NSString *escapedObject = [[sender representedObject] stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+    NSString *escapedObject = [[sender representedObject][@"cmd"] stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+    NSString *escapedProfile = [[sender representedObject][@"profile"] stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+    if(!escapedProfile) {
+        escapedProfile=@"Default Session";
+    }
     
     // Check if Url
-    NSURL* url = [NSURL URLWithString:[sender representedObject]];
+    NSURL* url = [NSURL URLWithString:[sender representedObject][@"cmd"]];
     if(url)
     {
         [[NSWorkspace sharedWorkspace] openURL:url];
@@ -363,21 +367,21 @@
                                     @"tell application \"iTerm\" \n"
                                     @"  tell the current terminal \n"
                                     @"      if isRunning then \n"
-                                    @"          set newSession to (launch session \"Default Session\") \n"
+                                    @"          set newSession to (launch session \"%1$@\") \n"
                                     @"          tell the last session \n"
                                     @"              write text \"clear\" \n"
-                                    @"              write text \"%1$@\" \n"
+                                    @"              write text \"%2$@\" \n"
                                     @"          end tell \n"
                                     @"      else \n"
                                     @"          tell the current session \n"
                                     @"              write text \"clear\" \n"
-                                    @"              write text \"%1$@\" \n"
+                                    @"              write text \"%2$@\" \n"
                                     @"              activate \n"
                                     @"          end tell \n"
                                     @"      end if \n"
                                     @"  end tell \n"
                                     @"end tell \n"
-                                    , escapedObject]];
+                                    , escapedProfile, escapedObject]];
         [iTerm2 executeAndReturnError:nil];
     } else {
         NSAppleScript* terminalapp = [[NSAppleScript alloc] initWithSource:

--- a/apple-scripts/iterm2.applescript
+++ b/apple-scripts/iterm2.applescript
@@ -8,15 +8,15 @@ set isRunning to ApplicationIsRunning("iTerm")
 tell application "iTerm"
 	tell the current terminal
 		if isRunning then
-			set newSession to (launch session "Default Session")
+			set newSession to (launch session "%1$@")
 			tell the last session
 				write text "clear"
-				write text "%1$@"
+				write text "%2$@"
 			end tell
 		else
 			tell the current session
 				write text "clear"
-				write text "%1$@"
+				write text "%2$@"
 				activate
 			end tell
 		end if


### PR DESCRIPTION
This pull request adds the ability to specify iTerm profiles per connection. iTerm profiles can change the appearance and behavior of the terminal. This change causes Shuttle to tell iTerm to open sessions using a profile by name.

Example config entry:

```
{
    "name": "jenkins",
    "cmd": "ssh root@jenkins.corp.com",
    "profile": "Test Profile"
},
```

"Test Profile" correlates to a profile of the same name in iTerm's preferences.

Previously, only the command string was associated with each menu entry in Shuttle's menu. I've changed this so the NSDictionary for that entry is the associated object. Then, when the entry is clicked and openHost is ran, the profile name is extracted from the dictionary and escaped, as well as the cmd as before. Then they are both passed to updated applescript which tells iTerm to use the specified profile.