### PR TITLE
Feature add open_in and default_theme. Fix editor settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,16 @@ A simple SSH shortcut menu for OS X
 
 ![How Shuttle works](https://raw.github.com/fitztrev/shuttle/gh-pages/img/how-shuttle-works.gif)
 
-***Sidenote***: *Many people ask, so here's how I have [my terminal setup](https://github.com/fitztrev/shuttle/wiki/My-Terminal-Prompt).*
+**Sidenote**: *Many people ask, so here's how I have [my terminal setup](https://github.com/fitztrev/shuttle/wiki/My-Terminal-Prompt).*
 
 ## Installation
 
 1. Download [Shuttle](http://fitztrev.github.io/shuttle/)
 2. Copy to Applications
 
-
-## Customization
-
-The default, out-of-the-box configuration should be good enough to get started. However, if you're looking to customize the appearance further, here are a few advanced tips.
-
-### JSON Options
-#### Global settings
-##### ```"editor": "VALUE",```
+## JSON Options
+### Global settings
+#### ```"editor": "VALUE",```
 _This changes the app that opens settings.json for editing (Global Setting)_
 
 Possible values are ```default```, ```nano```, ```vi```, ```vim``` or any terminal based editor. 
@@ -32,66 +27,84 @@ would open ```~/.shuttle.json``` in vim
 
 ----
 
-##### ```"launch_at_login": VALUE,```
+#### ```"launch_at_login": VALUE,```
 _This allows you to flag the shuttle.app to start automatically (Global Setting)_
 
 Possible values are ```true``` or ```false```
 
 ----
 
-##### ```"terminal": "VALUE",```
+#### ```"terminal": "VALUE",```
 _This allows you to set the default terminal (Global Setting)_
 
 Possible values are ```Terminal.app``` or ```iTerm```
 
 ----
 
-##### ```"iTerm_version": "VALUE",```
+#### ```"iTerm_version": "VALUE",```
 _This changes the applescripts for iTerm (Global Setting)_
 
 Possible values are ```stable``` or ```nightly```
 
 **If ```terminal``` is set to ```iTerm``` this setting is mandatory**
 
+_This setting is ignored if your terminal is set to ```Terminal.app```_
+
 ----
 
-##### ```"open_in": "VALUE",```
+#### ```"default_theme": "Homebrew",```
+_This sets the Terminal theme for all windows. (Global Setting)_ 
+
+Possible values are the Profile names in your terminal preferences. iTerm ships with one Profile named "Default". OS X Terminal ships with several. To see the names see the preferences area of the terminal you are using.
+
+In iTerm the profile names are case sensitive.
+
+**Please ensure the theme names you set are valid. If shuttle passes theme "Dagobah" and it does not exist in iTerm or OS X Terminal then your command won't run. This is because the applescripts are not making any checks to see if the theme you passed actually exists within the terminal application.** 
+
+This setting can be overwritten by the command level "theme" settings
+
+----
+
+#### ```"open_in": "VALUE",```
 _This changes the default action for how commands are opened (Global Setting)_
 
 Possible values are ```tab``` or ```new```. 
 
 ```tab``` opens the command in the active terminal in a new tab. 
 
-```new``` opens the command in window. This setting can be overwritten by the command level ```"inTerminal"``` settings
+```new``` opens the command in a new window. 
+
+This setting can be overwritten by the command level ```"inTerminal"``` settings
 
 ----
-##### ```"show_ssh_config_hosts": VALUE,```
+
+#### ```"show_ssh_config_hosts": VALUE,```
 _This changes parsing ssh config. By default, Shuttle will parse your ```~/.ssh/config``` file for hosts. (Global Setting)_
 
-Possbile values are ```false``` or ```true```
+Possible values are ```false``` or ```true```
 
 ----
 
-##### ```"ssh_config_ignore_hosts": ["VALUE", "VALUE"],```
-_This will ignore hosts in the ssh config. (Global Settings)_
+#### ```"ssh_config_ignore_hosts": ["VALUE", "VALUE"],```
+_This will ignore hosts in the ssh config. (Global Setting)_
 
-Possible values are the hosts in your config that you want to ignore. If you had github.com and git.example.com in your ssh config, to ignor them you set:
+Possible values are the hosts in your config that you want to ignore. If you had github.com and git.example.com in your ssh config, to ignore them you set:
 
 ```"ssh_config_ignore_hosts": ["github.com", "git.example.com"],```
 
 ----
 
-##### ```"ssh_config_ignore_keywords": ["VALUE"],```
-_This will ignore keywoards in your ssh config. (Global Settings)_
+#### ```"ssh_config_ignore_keywords": ["VALUE"],```
+_This will ignore keywords in your ssh config. (Global Setting)_
 
 Possible values are the keywords in your ssh config that you want to ignore.
 
 ----
 
 **Additional ssh config customization** 
-##### Nested menus for `~/.ssh/config` hosts
+#### Nested menus for `~/.ssh/config` hosts
 
-###### Create a menu item at "work" > "servers" > "web01"
+##### Create a menu item at "work" > "servers" > "web01"
 
 ```
 Host work/servers/web01
@@ -105,9 +118,34 @@ Host gandalf
         HostName user@web01.example.com
 ```
 
-#### Command level settings
+### Command level settings
+_Command level settings unique to your command and will overwrite the Global setting equivalent_
+
+#### ```"cmd": "VALUE"```
+_This is the command / script that will be launched in the terminal. (Command setting)_
+
+Where Value is a command or script. 
+```
+"cmd": "ps aux | grep [s]sh"
+```
+Would check for ssh processes.
+
+----
+
+#### ```"name": "VALUE"```
+_This sets the text that will appear in shuttles drop down menu. (Command setting)_
+
+Were Value is the text you want to see in the drop down menu for this command. 
+```
+"name": "SSH to my wordpress blog"
+```
+
+This value can also set the title of the terminal window if ```"title" :"VALUE"``` is not set.
+
+----
+
 #### ```"inTerminal": "VALUE",```
-_This sets how command will open in the terminal window_
+_This sets how command will open in the terminal window. (Command setting)_
 
 Possible values are ```new```, ```tab```, or ```current```
 
@@ -127,15 +165,15 @@ Do this as a precaution as it could be possible to run a command on the wrong ho
 
 ----
 
-##### ```"theme": "VALUE",```
-_This sets the theme for the terminal window_
+#### ```"theme": "VALUE",```
+_This sets the theme for the terminal window. (Command setting)_
 
-Possbile values are the profile names for iTerm or Terminal.app
+Possible values are the profile names for iTerm or OS X Terminal.
 
----
+----
 
-##### ```"title": "VALUE"```
-_This sets the text that will appear in the terminal's title bar_
+#### ```"title": "VALUE"```
+_This sets the text that will appear in the terminal's title bar. (Command setting)_
 
 Where VALUE is the text you want to set in the terminals title bar. 
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ The default, out-of-the-box configuration should be good enough to get started. 
 
 ### JSON Options
 #### Global settings
-##### ```"editor": "default",```
+##### ```"editor": "VALUE",```
 _This changes the app that opens settings.json for editing (Global Setting)_
 
-Valid settings are ```default``` ```nano``` ```vi``` ```vim``` or any terminal based editor. 
+Possible values are ```default```, ```nano```, ```vi```, ```vim``` or any terminal based editor. 
 ```default``` opens settings.json in whatever app is registered as the default for extension ```.json```
 ```
 "editor": "vim",
@@ -32,56 +32,63 @@ would open ```~/.shuttle.json``` in vim
 
 ----
 
-##### ```"launch_at_login": false,```
+##### ```"launch_at_login": VALUE,```
 _This allows you to flag the shuttle.app to start automatically (Global Setting)_
 
-Valid settings are ```true``` or ```false```
+Possible values are ```true``` or ```false```
 
 ----
 
-##### ```"terminal": "iTerm",```
+##### ```"terminal": "VALUE",```
 _This allows you to set the default terminal (Global Setting)_
 
-Valid settings are ```Terminal.app``` or ```iTerm```
+Possible values are ```Terminal.app``` or ```iTerm```
 
 ----
 
-##### ```"iTerm_version": "nightly",```
+##### ```"iTerm_version": "VALUE",```
 _This changes the applescripts for iTerm (Global Setting)_
 
-Valid settings are ```stable``` or ```nightly```
+Possible values are ```stable``` or ```nightly```
 
-**If the terminal is set to ```iTerm``` this setting is mandatory**
+**If ```terminal``` is set to ```iTerm``` this setting is mandatory**
 
 ----
 
-##### ```"open_in": "tab",```
+##### ```"open_in": "VALUE",```
 _This changes the default action for how commands are opened (Global Setting)_
 
-Valid settings are ```tab``` or ```new```. ```tab``` opens the command in the active terminal in a new tab. ```new``` opens the command in window. This setting can be overwritten b$
+Possible values are ```tab``` or ```new```. 
+
+```tab``` opens the command in the active terminal in a new tab. 
+
+```new``` opens the command in window. This setting can be overwritten by the command level ```"inTerminal"``` settings
 
 ----
-##### ``````"show_ssh_config_hosts": false,````
-_This changes parsing ssh config. By default, Shuttle will parse your `~/.ssh/config` file for hosts. (Global Setting)_
+##### ```"show_ssh_config_hosts": VALUE,```
+_This changes parsing ssh config. By default, Shuttle will parse your ```~/.ssh/config``` file for hosts. (Global Setting)_
 
-Valid settings are ```false``` or ```true````
+Possbile values are ```false``` or ```true```
 
 ----
 
-##### ```"ssh_config_ignore_hosts": ["github.com", "git.example.com"],```
+##### ```"ssh_config_ignore_hosts": ["VALUE", "VALUE"],```
 _This will ignore hosts in the ssh config. (Global Settings)_
 
-Valid settings are the hosts in your config that you want to ignore. 
+Possible values are the hosts in your config that you want to ignore. If you had github.com and git.example.com in your ssh config, to ignor them you set:
+
+```"ssh_config_ignore_hosts": ["github.com", "git.example.com"],```
 
 ----
 
-##### ```"ssh_config_ignore_keywords": ["git"],```
+##### ```"ssh_config_ignore_keywords": ["VALUE"],```
 _This will ignore keywoards in your ssh config. (Global Settings)_
 
-Valid settings are the keywords in your ssh config that you want to ignore.
+Possible values are the keywords in your ssh config that you want to ignore.
 
 ----
-***Additional ssh config customization** 
+
+**Additional ssh config customization** 
 ##### Nested menus for `~/.ssh/config` hosts
 
 ###### Create a menu item at "work" > "servers" > "web01"
@@ -99,10 +106,10 @@ Host gandalf
 ```
 
 #### Command level settings
-#### ```"inTerminal": "new",```
+#### ```"inTerminal": "VALUE",```
 _This sets how command will open in the terminal window_
 
-Valid settings are ```new```, ```tab```, or ```current```
+Possible values are ```new```, ```tab```, or ```current```
 
 ```new``` opens the command in a new terminal window. 
 
@@ -112,24 +119,27 @@ Valid settings are ```new```, ```tab```, or ```current```
 
 When using using ```current``` I recommend that you wrap the command in some user input like this:
 
-```echo "are you sure y/n"; read sure; if [ "$sure" == "y" ]; then echo "running command" && ps aux | grep [s]sh; else echo "exiting..."; fi```
+```
+echo "are you sure y/n"; read sure; if [ "$sure" == "y" ]; then echo "running command" && ps aux | grep [s]sh; else echo "exiting..."; fi
+```
 
 Do this as a precaution as it could be possible to run a command on the wrong host. 
+
 ----
 
-##### ```"theme": "Default",```
+##### ```"theme": "VALUE",```
 _This sets the theme for the terminal window_
 
-Valid settings are the profile names for iTerm or Terminal.app
+Possbile values are the profile names for iTerm or Terminal.app
 
 ---
 
-##### ```"title": "grep foo"```
+##### ```"title": "VALUE"```
 _This sets the text that will appear in the terminal's title bar_
 
+Where VALUE is the text you want to set in the terminals title bar. 
+
 If ```title``` is missing shuttle uses the menu's name and sets this as ```title```
-
-
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In iTerm the profile names are case sensitive.
 
 **Please ensure the theme names you set are valid. If shuttle passes theme "Dagobah" and it does not exist in iTerm or OS X Terminal then your command won't run. This is because the applescripts are not making any checks to see if the theme you passed actually exists within the terminal application.** 
 
-This setting can be overwritten by the command level "theme" settings
+This setting can be overwritten by the command level ```"theme"``` settings
 
 ----
 
@@ -119,7 +119,7 @@ Host gandalf
 ```
 
 ### Command level settings
-_Command level settings unique to your command and will overwrite the Global setting equivalent_
+_Command level settings are unique to your command and will overwrite the Global setting equivalent_
 
 #### ```"cmd": "VALUE"```
 _This is the command / script that will be launched in the terminal. (Command setting)_
@@ -169,6 +169,8 @@ Do this as a precaution as it could be possible to run a command on the wrong ho
 _This sets the theme for the terminal window. (Command setting)_
 
 Possible values are the profile names for iTerm or OS X Terminal.
+
+If ```"theme"``` is not set and ```"default_theme"``` is not set then shuttle passes Profile ```Default``` for iTerm and Profile ```basic``` for OS X terminal.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -13,47 +13,122 @@ A simple SSH shortcut menu for OS X
 1. Download [Shuttle](http://fitztrev.github.io/shuttle/)
 2. Copy to Applications
 
+
 ## Customization
 
 The default, out-of-the-box configuration should be good enough to get started. However, if you're looking to customize the appearance further, here are a few advanced tips.
 
-### Disabling `~/.ssh/config` hosts
+### JSON Options
+#### Global settings
+##### ```"editor": "default",```
+_This changes the app that opens settings.json for editing (Global Setting)_
 
-By default, Shuttle will parse your `~/.ssh/config` file for hosts.
-
-##### To disable all ~/.ssh/config entries:
-
+Valid settings are ```default``` ```nano``` ```vi``` ```vim``` or any terminal based editor. 
+```default``` opens settings.json in whatever app is registered as the default for extension ```.json```
 ```
-"show_ssh_config_hosts": false,
-```
+"editor": "vim",
+``` 
+would open ```~/.shuttle.json``` in vim
 
-#### Disable specific hosts:
+----
 
-```
-"ssh_config_ignore_hosts": ["github.com", "git.example.com"],
-```
+##### ```"launch_at_login": false,```
+_This allows you to flag the shuttle.app to start automatically (Global Setting)_
 
-#### Disable hosts that contain a keyword:
+Valid settings are ```true``` or ```false```
 
-```
-"ssh_config_ignore_keywords": ["git"],
-```
+----
 
-### Nested menus for `~/.ssh/config` hosts
+##### ```"terminal": "iTerm",```
+_This allows you to set the default terminal (Global Setting)_
 
-#### Create a menu item at "work" > "servers" > "web01"
+Valid settings are ```Terminal.app``` or ```iTerm```
+
+----
+
+##### ```"iTerm_version": "nightly",```
+_This changes the applescripts for iTerm (Global Setting)_
+
+Valid settings are ```stable``` or ```nightly```
+
+**If the terminal is set to ```iTerm``` this setting is mandatory**
+
+----
+
+##### ```"open_in": "tab",```
+_This changes the default action for how commands are opened (Global Setting)_
+
+Valid settings are ```tab``` or ```new```. ```tab``` opens the command in the active terminal in a new tab. ```new``` opens the command in window. This setting can be overwritten b$
+
+----
+##### ``````"show_ssh_config_hosts": false,````
+_This changes parsing ssh config. By default, Shuttle will parse your `~/.ssh/config` file for hosts. (Global Setting)_
+
+Valid settings are ```false``` or ```true````
+
+----
+
+##### ```"ssh_config_ignore_hosts": ["github.com", "git.example.com"],```
+_This will ignore hosts in the ssh config. (Global Settings)_
+
+Valid settings are the hosts in your config that you want to ignore. 
+
+----
+
+##### ```"ssh_config_ignore_keywords": ["git"],```
+_This will ignore keywoards in your ssh config. (Global Settings)_
+
+Valid settings are the keywords in your ssh config that you want to ignore.
+
+----
+***Additional ssh config customization** 
+##### Nested menus for `~/.ssh/config` hosts
+
+###### Create a menu item at "work" > "servers" > "web01"
 
 ```
 Host work/servers/web01
-	HostName user@web01.example.com
+        HostName user@web01.example.com
 ```
 \- *or* -
 
 ```
 Host gandalf
-	# shuttle.name = work/servers/web01 (webserver)
-	HostName user@web01.example.com
+        # shuttle.name = work/servers/web01 (webserver)
+        HostName user@web01.example.com
 ```
+
+#### Command level settings
+#### ```"inTerminal": "new",```
+_This sets how command will open in the terminal window_
+
+Valid settings are ```new```, ```tab```, or ```current```
+
+```new``` opens the command in a new terminal window. 
+
+```tab``` opens the command in the active terminal window in a new tab. 
+
+```current``` opens the command in the active terminal's window. 
+
+When using using ```current``` I recommend that you wrap the command in some user input like this:
+
+```echo "are you sure y/n"; read sure; if [ "$sure" == "y" ]; then echo "running command" && ps aux | grep [s]sh; else echo "exiting..."; fi```
+
+Do this as a precaution as it could be possible to run a command on the wrong host. 
+----
+
+##### ```"theme": "Default",```
+_This sets the theme for the terminal window_
+
+Valid settings are the profile names for iTerm or Terminal.app
+
+---
+
+##### ```"title": "grep foo"```
+_This sets the text that will appear in the terminal's title bar_
+
+If ```title``` is missing shuttle uses the menu's name and sets this as ```title```
+
 
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ A simple SSH shortcut menu for OS X
 1. Download [Shuttle](http://fitztrev.github.io/shuttle/)
 2. Copy to Applications
 
+## JSON Path Change
+
+In your home directory create a file called ```~/.shuttle.path```
+In this file should be a single line with the path to the JSON settings file. 
+
+```
+/Users/thshdw/Dropbox/shuttle/shuttle.json
+``` 
+shuttle will read ```~/.shuttle.path``` first and use its contents as the path to your JSON file.
+
 ## JSON Options
 ### Global settings
 #### ```"editor": "VALUE",```

--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -15,16 +15,20 @@
     
     NSStatusItem *statusItem;
     NSString *shuttleConfigFile;
-    NSString *shuttleJSONPath;
     
     // This is for the JSON File
     NSDate *configModified;
     NSDate *sshConfigUser;
     NSDate *sshConfigSystem;
     
-    NSString *terminalPref;
-    NSString *editorPref;
-    NSString *iTermVersion;
+    //Global settings Pref in the JSON file.
+    NSString *shuttleJSONPathPref; //alternate path the JSON file
+    NSString *terminalPref; //which terminal will we be using iTerm or Terminal.app
+    NSString *editorPref; //what app opens the JSON fiile vi, nano...
+    NSString *iTermVersionPref; //which version of iTerm nightly or stable
+    NSString *openInPref; //by default are commands opened in tabs or new windows.
+    
+    //used to gather ssh config settings
     NSMutableArray* shuttleHosts;
     NSMutableArray* ignoreHosts;
     NSMutableArray* ignoreKeywords;

--- a/Shuttle/AppDelegate.h
+++ b/Shuttle/AppDelegate.h
@@ -27,6 +27,7 @@
     NSString *editorPref; //what app opens the JSON fiile vi, nano...
     NSString *iTermVersionPref; //which version of iTerm nightly or stable
     NSString *openInPref; //by default are commands opened in tabs or new windows.
+    NSString *themePref; //The global theme.
     
     //used to gather ssh config settings
     NSMutableArray* shuttleHosts;

--- a/Shuttle/Shuttle-Info.plist
+++ b/Shuttle/Shuttle-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.4</string>
+	<string>1.2.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.4</string>
+	<string>1.2.5</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Shuttle/shuttle.default.json
+++ b/Shuttle/shuttle.default.json
@@ -7,24 +7,22 @@
   ],
   "editor": "default",
   "launch_at_login": false,
+  "terminal": "Terminal.app",
+  "iTerm_version": "nightly",
+  "default_theme": "Homebrew",
+  "open_in": "new",  
   "show_ssh_config_hosts": false,
   "ssh_config_ignore_hosts": [  ],
   "ssh_config_ignore_keywords": [  ],
-  "terminal": "iTerm",
-  "iTerm_version": "nightly",
-  "open_in": "tab",
   "hosts": [
     {
-      "cmd": "ps aux | grep foo",
-      "inTerminal": "new",
-      "name": "foo - Opens in a new terminal window",
-      "theme": "Default",
-      "title": "grep foo"
+      "cmd": "ps aux | grep defaults",
+      "name": "Grep - Opens in Default-window-theme-title"
     },
     {
       "Spouses Servers": [
         {
-          "cmd": "echo '—->WARNING<-- Running a command in this active terminal! Are you sure? y/n'; read sure; if [ $sure == y ]; then echo running command... && tail -f /var/log/messages; else echo exiting...; fi",
+          "cmd": "echo '—->WARNING<-- Running a command in this active terminal! Are you sure? y/n'; read sure; if [ $sure == y ]; then echo running command... && tail -f /var/log/current; else echo exiting...; fi",
           "inTerminal": "current",
           "name": "Logs - Opens in the current active terminal window"
         },
@@ -32,11 +30,17 @@
           "Jane’s Servers": [
             {
               "cmd": "ssh username@blog2.example.com",
-              "name": "WP - Opens in active terminal in a new tab"
+              "inTerminal": "tab",
+              "name": "SSH blog - Opens in Tab of active window",
+              "theme": "basic",
+              "title": "title of tab"
             },
-			{ 
+            {
               "cmd": "ssh username@shop1.example.com",
-              "name": "Shop - Opens in active terminal in a new tab"
+              "inTerminal": "new",
+              "name": "SSH Shop - Opens in New Window",
+              "theme": "basic",
+              "title": "title of new window"
             }
           ]
         }
@@ -46,26 +50,9 @@
       "Vagrant": [
         {
           "cmd": "ssh vagrant@127.0.0.1 -p 2222 -i ~/.vagrant.d/insecure_private_key",
-          "name": "SSH - Opens in active terminal in a new tab"
+          "name": "Vagrant - Opens in default-window-theme-title"
         }
       ]
     }
   ]
 }
-        
-        
-        
-        
-        
-        
-        
-
-        
-        
-        
-        
-        
-        
-        
-        
-        

--- a/Shuttle/shuttle.default.json
+++ b/Shuttle/shuttle.default.json
@@ -6,17 +6,18 @@
     "For more information on how to configure, please see http://fitztrev.github.io/shuttle/"
   ],
   "editor": "default",
-  "iTerm_version": "nightly",
   "launch_at_login": false,
-  "show_ssh_config_hosts": true,
+  "show_ssh_config_hosts": false,
   "ssh_config_ignore_hosts": [  ],
   "ssh_config_ignore_keywords": [  ],
   "terminal": "iTerm",
+  "iTerm_version": "nightly",
+  "open_in": "tab",
   "hosts": [
     {
       "cmd": "ps aux | grep foo",
       "inTerminal": "new",
-      "name": "look for process foo",
+      "name": "foo - Opens in a new terminal window",
       "theme": "Default",
       "title": "grep foo"
     },
@@ -25,35 +26,19 @@
         {
           "cmd": "echo '—->WARNING<-- Running a command in this active terminal! Are you sure? y/n'; read sure; if [ $sure == y ]; then echo running command... && tail -f /var/log/messages; else echo exiting...; fi",
           "inTerminal": "current",
-          "name": "Look at the Logs"
+          "name": "Logs - Opens in the current active terminal window"
         },
         {
           "Jane’s Servers": [
             {
               "cmd": "ssh username@blog2.example.com",
-              "name": "Wordpress Box"
+              "name": "WP - Opens in active terminal in a new tab"
             },
 			{ 
               "cmd": "ssh username@shop1.example.com",
-              "name": "Shopping Site"
+              "name": "Shop - Opens in active terminal in a new tab"
             }
           ]
-        }
-      ]
-    },
-    {
-      "Work": [
-        {
-          "cmd": "ssh username@dev.example.net -p 4000",
-          "name": "dev.example.net"
-        },
-        {
-          "cmd": "ssh username@staging.example.net -p 5000",
-          "name": "staging.example.net"
-        },
-        {
-          "cmd": "ssh username@example.net -p 6000",
-          "name": "production.example.net"
         }
       ]
     },
@@ -61,7 +46,7 @@
       "Vagrant": [
         {
           "cmd": "ssh vagrant@127.0.0.1 -p 2222 -i ~/.vagrant.d/insecure_private_key",
-          "name": "precise32"
+          "name": "SSH - Opens in active terminal in a new tab"
         }
       ]
     }


### PR DESCRIPTION
Added a new feature ```"open_in": "VALUE"``` is a global setting which sets how commands are open. Do they open in new tabs or new windows? This setting accepts the value of ```"tab"``` or ```"new"```

Added a new feature ```"default_theme": "VALUE"``` is a global setting which sets the default theme for all terminal windows. 

The settings editor had a bug that prevented a terminal based editor like vim from opening.

Cleaned up the default JSON file and changed the names to reflect the action.

Changed the readme.md to reflect all options.

Added alert boxes on errors for ```"iTerm_version": "VALUE"``` and ```"inTerminal": "VALUE"```

![screen shot 2015-10-30 at 11 06 24 am](https://cloud.githubusercontent.com/assets/4992951/10857358/df7326ca-7f0a-11e5-9c8e-ea79986ffb76.png)

![screen shot 2015-10-30 at 11 08 15 am](https://cloud.githubusercontent.com/assets/4992951/10857362/e670c806-7f0a-11e5-880f-7b58151ea75d.png)

![screen shot 2015-10-30 at 11 09 14 am](https://cloud.githubusercontent.com/assets/4992951/10857366/ed4c8962-7f0a-11e5-932b-b9a940c28bea.png)
