### PR TITLE
modify parseSSHConfigFile to only keep first host alias

### DIFF
--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -158,7 +158,11 @@
         
         if ([first isEqualToString:@"Host"]) {
             // a new host section
-            key = second;
+            
+            // split multiple aliases on space and only save the first
+            NSArray* hostAliases = [second componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            hostAliases = [hostAliases filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF != ''"]];
+            key = [hostAliases firstObject];
             servers[key] = [[NSMutableDictionary alloc] init];
         }
     }


### PR DESCRIPTION
Hi,
ssh_config allows multiple patterns on the Host argument, which Shuttle parses into the menu and then passes on to `ssh` when activated.

This change keeps the menu clean as it only keeps the first argument to `Host` and will allow for hosts defined like:
```
Host prod/host host.prod
	HostName myserver.local
```

Cheers,
Kees