### PR TITLE
Add more ssh_config directives #161

### DIFF
--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -300,7 +300,9 @@
             // system should be appended to. part hold the last part of the splitted string (aka hostname).
             if (itemList) {
                 // build the corresponding ssh command
-                NSString* cmd = [NSString stringWithFormat:@"ssh %@", key];
+            //  NSString* cmd = [NSString stringWithFormat:@"ssh %@", key];
+                NSString* cmd = servers[key][@"cmd"] ?
+                  cmd = servers[key][@"cmd"] : [NSString stringWithFormat:@"ssh %@", key];
                 
                 // inject the data into the json parser result
                 [itemList addObject:[NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:leaf, cmd, nil]
@@ -465,7 +467,7 @@
     NSArray *passParameters = @[escapedObject, terminalTheme, terminalTitle];
     
 // Check if Url
-    NSURL* url = [NSURL URLWithString:escapedObject];
+    NSURL* url = [NSURL URLWithString:[sender representedObject]];
     if(url)
     {
         [[NSWorkspace sharedWorkspace] openURL:url];


### PR DESCRIPTION
Instead of the following in AppDelegate.m:

```
  // if everything worked out we will see a non-nil itemList where the
    // system should be appended to. part hold the last part of the splitted string (aka hostname).
    if (itemList) {
        // build the corresponding ssh command
        NSString* cmd = [NSString stringWithFormat:@"ssh %@", key];
```

we change it to:

```
    // if everything worked out we will see a non-nil itemList where the
    // system should be appended to. part hold the last part of the splitted string (aka hostname).
    if (itemList) {      
        // build the corresponding ssh command
        NSString* cmd = servers[key][@"cmd"] ?
            cmd = servers[key][@"cmd"] : [NSString stringWithFormat:@"ssh %@", key];
```
