### PR TITLE
Ignore error from close first window after startup.

### DIFF
--- a/apple-scripts/iTermNightly/iTerm2-nightly-new-tab-default.applescript
+++ b/apple-scripts/iTermNightly/iTerm2-nightly-new-tab-default.applescript
@@ -19,7 +19,9 @@ on CommandRun(withCmd, withTheme, theTitle)
 			tell application "iTerm"
 				activate
 				delay 0.2
-				close first window
+				try
+					close first window
+				end try
 			end tell
 			
 			tell application "iTerm"

--- a/apple-scripts/iTermNightly/iTerm2-nightly-new-window.applescript
+++ b/apple-scripts/iTermNightly/iTerm2-nightly-new-window.applescript
@@ -18,7 +18,9 @@ on CommandRun(withCmd, withTheme, theTitle)
 		if it is not running then
 			activate
 			delay 0.2
-			close first window
+			try
+				close first window
+			end try
 		end if
 	end tell
 	tell application "iTerm"


### PR DESCRIPTION
The problem is in iTerm2 3.0.0, when Preferences/General/Startup is set
to "Don't Open Any Windows", it does not open a window when it starts
up. So "close first window" fails with an error. To handle this
scenario, we can simply wrap this statement in try / end try.