### PR TITLE
1.3.0 : French translations / "Error parsing config" i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project was created by [Trevor Fitzgerald](https://github.com/fitztrev). I 
 
 (In alphabetical order)
 
+* [Alexis NIVON](https://github.com/anivon)
 * [Alex Carter](https://github.com/blazeworx)
 * [bihicheng](https://github.com/bihicheng)
 * [Dave Eddy](https://github.com/bahamas10)

--- a/Shuttle.xcodeproj/project.pbxproj
+++ b/Shuttle.xcodeproj/project.pbxproj
@@ -74,6 +74,11 @@
 		A1B7B9F21DB54D9000809327 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/AboutWindowController.strings; sourceTree = "<group>"; };
 		A1D700051A5DCDF4003563E4 /* AboutWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AboutWindowController.h; sourceTree = "<group>"; };
 		A1D700061A5DCE8D003563E4 /* AboutWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AboutWindowController.m; sourceTree = "<group>"; };
+		BDCFF1521E4E890A00B365C9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		BDCFF1531E4E890A00B365C9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AboutWindowController.strings; sourceTree = "<group>"; };
+		BDCFF1541E4E890A00B365C9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		BDCFF1551E4E890A00B365C9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = fr; path = fr.lproj/Credits.rtf; sourceTree = "<group>"; };
+		BDCFF1561E4E890A00B365C9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C149EBF915D5214600B1F558 /* Shuttle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shuttle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C149EBFD15D5214600B1F558 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		C149EC0015D5214600B1F558 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -239,6 +244,7 @@
 				"zh-Hans",
 				Base,
 				es,
+				fr,
 			);
 			mainGroup = C149EBEE15D5214600B1F558;
 			productRefGroup = C149EBFA15D5214600B1F558 /* Products */;
@@ -305,6 +311,7 @@
 				A1B7B9F01DB54D8900809327 /* en */,
 				A1B7B9F11DB54D8C00809327 /* zh-Hans */,
 				A1B7B9F21DB54D9000809327 /* es */,
+				BDCFF1531E4E890A00B365C9 /* fr */,
 			);
 			name = AboutWindowController.xib;
 			sourceTree = "<group>";
@@ -316,6 +323,7 @@
 				A1B7B9E01DB53ED700809327 /* Base */,
 				A1B7B9E11DB53EDA00809327 /* zh-Hans */,
 				A1B7B9E61DB5436700809327 /* es */,
+				BDCFF1561E4E890A00B365C9 /* fr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -325,6 +333,7 @@
 			children = (
 				C149EC0715D5214600B1F558 /* en */,
 				A1B7B9E41DB5436700809327 /* es */,
+				BDCFF1541E4E890A00B365C9 /* fr */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -334,6 +343,7 @@
 			children = (
 				C149EC0D15D5214600B1F558 /* en */,
 				A1B7B9E51DB5436700809327 /* es */,
+				BDCFF1551E4E890A00B365C9 /* fr */,
 			);
 			name = Credits.rtf;
 			sourceTree = "<group>";
@@ -345,6 +355,7 @@
 				A1B7B9E21DB5436700809327 /* es */,
 				A1B7B9EE1DB54D7B00809327 /* zh-Hans */,
 				A1B7B9EF1DB54D7F00809327 /* en */,
+				BDCFF1521E4E890A00B365C9 /* fr */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";

--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -189,7 +189,7 @@
                                                 error:nil];
     // Check valid JSON syntax
     if ( !json ) {
-        NSMenuItem *menuItem = [menu insertItemWithTitle:@"Error parsing config"
+        NSMenuItem *menuItem = [menu insertItemWithTitle:NSLocalizedString(@"Error parsing config",nil)
                                                   action:false
                                            keyEquivalent:@""
                                                  atIndex:0

--- a/Shuttle/Shuttle-Info.plist
+++ b/Shuttle/Shuttle-Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.8</string>
+	<string>1.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.8</string>
+	<string>1.3.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Shuttle/fr.lproj/AboutWindowController.strings
+++ b/Shuttle/fr.lproj/AboutWindowController.strings
@@ -1,0 +1,15 @@
+
+/* Class = "NSTextFieldCell"; title = "Version"; ObjectID = "6fl-Xm-UPS"; */
+"6fl-Xm-UPS.title" = "Version";
+
+/* Class = "NSTextFieldCell"; title = "Copyright"; ObjectID = "Cmu-CQ-3V9"; */
+"Cmu-CQ-3V9.title" = "Copyright";
+
+/* Class = "NSWindow"; title = "Window"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Window";
+
+/* Class = "NSTextFieldCell"; title = "Program Name and Tag Line"; ObjectID = "tb3-eK-HAT"; */
+"tb3-eK-HAT.title" = "Program Name and Tag Line";
+
+/* Class = "NSButtonCell"; title = "Homepage"; ObjectID = "uUM-88-32s"; */
+"uUM-88-32s.title" = "Page d'accueil";

--- a/Shuttle/fr.lproj/Credits.rtf
+++ b/Shuttle/fr.lproj/Credits.rtf
@@ -1,0 +1,31 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf810
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+\paperw11900\paperh16840\vieww9600\viewh8400\viewkind0
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\partightenfactor0
+
+\f0\b\fs24 \cf0 Engineering:
+\b0 \
+	Quelques personnes\
+\
+
+\b Human Interface Design:
+\b0 \
+	Quelques autres personnes\
+\
+
+\b Testing:
+\b0 \
+	Personne, heureusement\
+\
+
+\b Documentation:
+\b0 \
+	Quiconque\
+\
+
+\b With special thanks to:
+\b0 \
+	Maman\
+}

--- a/Shuttle/fr.lproj/InfoPlist.strings
+++ b/Shuttle/fr.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/Shuttle/fr.lproj/Localizable.strings
+++ b/Shuttle/fr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+/*
+ Localizable.strings
+ Shuttle
+ Translations done by Alexis NIVON <anivon@alexisnivon.fr>
+*/
+
+"About " = "A propos de ";
+"Version: " = "Version: ";
+" - A simple SSH shortcut menu." = " - Le gestionnaire de raccourcis SSH.";
+"Error parsing config" = "Fichier de paramétrage invalide";

--- a/Shuttle/fr.lproj/MainMenu.strings
+++ b/Shuttle/fr.lproj/MainMenu.strings
@@ -1,0 +1,45 @@
+/*
+ Translations done by Alexis NIVON <anivon@alexisnivon.fr>
+ */
+
+/* Class = "NSMenu"; title = "AMainMenu"; ObjectID = "29"; */
+"29.title" = "AMainMenu";
+
+/* Class = "NSMenuItem"; title = "Shuttle"; ObjectID = "56"; */
+"56.title" = "Shuttle";
+
+/* Class = "NSMenu"; title = "Shuttle"; ObjectID = "57"; */
+"57.title" = "Shuttle";
+
+/* Class = "NSMenuItem"; title = "About Shuttle"; ObjectID = "58"; */
+"58.title" = "A propos de Shuttle";
+
+/* Class = "NSMenuItem"; title = "Quit Shuttle"; ObjectID = "136"; */
+"136.title" = "Quitter Shuttle";
+
+/* Class = "NSMenuItem"; title = "About"; ObjectID = "638"; */
+"638.title" = "A propos";
+
+/* Class = "NSMenuItem"; title = "Quit"; ObjectID = "644"; */
+"644.title" = "Quitter";
+
+/* Class = "NSMenuItem"; title = "Settings"; ObjectID = "646"; */
+"646.title" = "Paramétrage";
+
+/* Class = "NSMenu"; title = "Settings"; ObjectID = "647"; */
+"647.title" = "Paramétrage";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "648"; */
+"648.title" = "Modifier";
+
+/* Class = "NSMenuItem"; title = "Quit"; ObjectID = "649"; */
+"649.title" = "Quitter";
+
+/* Class = "NSMenuItem"; title = "Export"; ObjectID = "651"; */
+"651.title" = "Exporter";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "652"; */
+"652.title" = "Modifier";
+
+/* Class = "NSMenuItem"; title = "Import"; ObjectID = "653"; */
+"653.title" = "Importer";


### PR DESCRIPTION
## Summary 
- The `Error parsing config` message is now a `NSLocalizedString` (40c7ded)
- French translations added (8adf6db)

## Version
`1.3.0` and not `1.2.10` because no bugfix, only minor feature without BC break.

## Result
![image](https://cloud.githubusercontent.com/assets/4992953/22848710/9ad18a4e-eff6-11e6-8593-77ba106c58f3.png)
![image](https://cloud.githubusercontent.com/assets/4992953/22848715/a559dcb4-eff6-11e6-815a-35bf1f06bca6.png)
