### PR TITLE
Fixed bug with iTerm2 stable/nightly

### DIFF
--- a/apple-scripts/iTermNightly/iTerm2-nightly-new-tab-default.applescript
+++ b/apple-scripts/iTermNightly/iTerm2-nightly-new-tab-default.applescript
@@ -16,63 +16,63 @@ end scriptRun
 on CommandRun(withCmd, withTheme, theTitle)
 	tell application "iTerm"
 		if it is not running then
-			tell application "iTerm"
-				activate
-				delay 0.2
-				try
-					close first window
-				end try
-			end tell
-			
-			tell application "iTerm"
-				try
-					create window with profile withTheme
-				on error msg
-					create window with profile "Default"
-				end try
-				tell the current window
-					tell the current session
-						set name to theTitle
-						set profile to withTheme
-						write text withCmd
-					end tell
-				end tell
-			end tell
+			activate
+			if (count windows) is 0 then
+				NewWin(withTheme) of me
+			end if
+			SetWinParam(theTitle, withCmd) of me
+		else if (count windows) is 0 then
+			NewWin(withTheme) of me
+			SetWinParam(theTitle, withCmd) of me
 		else
-			--assume that iTerm is open and open a new tab
-			try
-				tell application "iTerm"
-					activate
-					tell the current window
-						try
-							create tab with profile withTheme
-						on error msg
-							create tab with profile "Default"
-						end try
-						tell the current tab
-							tell the current session
-								set name to theTitle
-								write text withCmd
-							end tell
-						end tell
-					end tell
-				end tell
-			on error msg
-				--if all iTerm windows are closed the app stays open. In this scenario iTerm has no "current window" and will give an error when trying to create the new tab.  
-				tell application "iTerm"
-					try
-						create window with profile withTheme
-					on error msg
-						create window with profile "Default"
-					end try
-					tell the current window
-						tell the current session
-							set name to theTitle
-							write text withCmd
-						end tell
-					end tell
-				end tell
-			end try
+			NewTab(withTheme) of me
+			SetTabParam(theTitle, withCmd) of me
 		end if
 	end tell
 end CommandRun
+
+on NewWin(argsTheme)
+	tell application "iTerm"
+		try
+			create window with profile argsTheme
+		on error msg
+			create window with profile "Default"
+		end try
+	end tell
+end NewWin
+
+on SetWinParam(argsTitle, argsCmd)
+	tell application "iTerm"
+		tell the current window
+			tell the current session
+				set name to argsTitle
+				write text argsCmd
+			end tell
+		end tell
+	end tell
+end SetWinParam
+
+on NewTab(argsTheme)
+	tell application "iTerm"
+		tell the current window
+			try
+				create tab with profile withTheme
+			on error msg
+				create tab with profile "Default"
+			end try
+		end tell
+	end tell
+end NewTab
+
+on SetTabParam(argsTitle, argsCmd)
+	tell application "iTerm"
+		tell the current window
+			tell the current tab
+				tell the current session
+					set name to argsTitle
+					write text argsCmd
+				end tell
+			end tell
+		end tell
+	end tell
+end SetTabParam

--- a/apple-scripts/iTermNightly/iTerm2-nightly-new-window.applescript
+++ b/apple-scripts/iTermNightly/iTerm2-nightly-new-window.applescript
@@ -17,18 +17,12 @@ on CommandRun(withCmd, withTheme, theTitle)
 	tell application "iTerm"
 		if it is not running then
 			activate
-			delay 0.2
-			try
-				close first window
-			end try
+			if (count windows) is 0 then
+				NewWin(withTheme) of me
+			end if
+		else
+			NewWin(withTheme) of me
 		end if
-	end tell
-	tell application "iTerm"
-		try
-			create window with profile withTheme
-		on error msg
-			create window with profile "Default"
-		end try
 		tell the current window
 			tell the current session
 				set name to theTitle
@@ -37,3 +31,13 @@ on CommandRun(withCmd, withTheme, theTitle)
 		end tell
 	end tell
 end CommandRun
+
+on NewWin(argsTheme)
+	tell application "iTerm"
+		try
+			create window with profile argsTheme
+		on error msg
+			create window with profile "Default"
+		end try
+	end tell
+end NewWin

--- a/apple-scripts/iTermStable/iTerm2-stable-new-tab-default.applescript
+++ b/apple-scripts/iTermStable/iTerm2-stable-new-tab-default.applescript
@@ -16,63 +16,63 @@ end scriptRun
 on CommandRun(withCmd, withTheme, theTitle)
 	tell application "iTerm"
 		if it is not running then
-			tell application "iTerm"
-				activate
-				delay 0.2
-				try
-					close first window
-				end try
-			end tell
-			
-			tell application "iTerm"
-				try
-					create window with profile withTheme
-				on error msg
-					create window with profile "Default"
-				end try
-				tell the current window
-					tell the current session
-						set name to theTitle
-						set profile to withTheme
-						write text withCmd
-					end tell
-				end tell
-			end tell
+			activate
+			if (count windows) is 0 then
+				NewWin(withTheme) of me
+			end if
+			SetWinParam(theTitle, withCmd) of me
+		else if (count windows) is 0 then
+			NewWin(withTheme) of me
+			SetWinParam(theTitle, withCmd) of me
 		else
-			--assume that iTerm is open and open a new tab
-			try
-				tell application "iTerm"
-					activate
-					tell the current window
-						try
-							create tab with profile withTheme
-						on error msg
-							create tab with profile "Default"
-						end try
-						tell the current tab
-							tell the current session
-								set name to theTitle
-								write text withCmd
-							end tell
-						end tell
-					end tell
-				end tell
-			on error msg
-				--if all iTerm windows are closed the app stays open. In this scenario iTerm has no "current window" and will give an error when trying to create the new tab.  
-				tell application "iTerm"
-					try
-						create window with profile withTheme
-					on error msg
-						create window with profile "Default"
-					end try
-					tell the current window
-						tell the current session
-							set name to theTitle
-							write text withCmd
-						end tell
-					end tell
-				end tell
-			end try
+			NewTab(withTheme) of me
+			SetTabParam(theTitle, withCmd) of me
 		end if
 	end tell
 end CommandRun
+
+on NewWin(argsTheme)
+	tell application "iTerm"
+		try
+			create window with profile argsTheme
+		on error msg
+			create window with profile "Default"
+		end try
+	end tell
+end NewWin
+
+on SetWinParam(argsTitle, argsCmd)
+	tell application "iTerm"
+		tell the current window
+			tell the current session
+				set name to argsTitle
+				write text argsCmd
+			end tell
+		end tell
+	end tell
+end SetWinParam
+
+on NewTab(argsTheme)
+	tell application "iTerm"
+		tell the current window
+			try
+				create tab with profile withTheme
+			on error msg
+				create tab with profile "Default"
+			end try
+		end tell
+	end tell
+end NewTab
+
+on SetTabParam(argsTitle, argsCmd)
+	tell application "iTerm"
+		tell the current window
+			tell the current tab
+				tell the current session
+					set name to argsTitle
+					write text argsCmd
+				end tell
+			end tell
+		end tell
+	end tell
+end SetTabParam

--- a/apple-scripts/iTermStable/iTerm2-stable-new-window.applescript
+++ b/apple-scripts/iTermStable/iTerm2-stable-new-window.applescript
@@ -17,18 +17,12 @@ on CommandRun(withCmd, withTheme, theTitle)
 	tell application "iTerm"
 		if it is not running then
 			activate
-			delay 0.2
-			try
-				close first window
-			end try
+			if (count windows) is 0 then
+				NewWin(withTheme) of me
+			end if
+		else
+			NewWin(withTheme) of me
 		end if
-	end tell
-	tell application "iTerm"
-		try
-			create window with profile withTheme
-		on error msg
-			create window with profile "Default"
-		end try
 		tell the current window
 			tell the current session
 				set name to theTitle
@@ -37,3 +31,13 @@ on CommandRun(withCmd, withTheme, theTitle)
 		end tell
 	end tell
 end CommandRun
+
+on NewWin(argsTheme)
+	tell application "iTerm"
+		try
+			create window with profile argsTheme
+		on error msg
+			create window with profile "Default"
+		end try
+	end tell
+end NewWin


### PR DESCRIPTION
The logic of the current scripts for iTerm2 stable/nightly doesn't play well with the iTerm2 startup options (Preferences/General, the Startup dropdown menu). This commit fixes that.