### PR TITLE
Fix NSURL misdetection routing SSH commands to openURL

### DIFF
--- a/Shuttle.xcodeproj/project.pbxproj
+++ b/Shuttle.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				"zh-Hans",
 				Base,
@@ -454,7 +455,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Shuttle/Shuttle-Prefix.pch";
 				INFOPLIST_FILE = "Shuttle/Shuttle-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "shuttle.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -470,7 +471,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Shuttle/Shuttle-Prefix.pch";
 				INFOPLIST_FILE = "Shuttle/Shuttle-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "shuttle.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;

--- a/Shuttle/AppDelegate.m
+++ b/Shuttle/AppDelegate.m
@@ -558,7 +558,10 @@
     NSURL *url;
     if ( ![terminalWindow isEqualToString:@"virtual"] ) {
         passParameters = @[escapedObject, terminalTheme, terminalTitle];
-        url = [NSURL URLWithString:escapedObject];
+        NSURL *candidateURL = [NSURL URLWithString:escapedObject];
+        if (candidateURL && ([candidateURL.scheme isEqualToString:@"http"] || [candidateURL.scheme isEqualToString:@"https"])) {
+            url = candidateURL;
+        }
     }
     else {
         passParameters = @[escapedObject, terminalTitle];
@@ -700,7 +703,11 @@
             [containerEvent setParamDescriptor:arguments forKeyword:keyDirectObject];
         }
         //Execute the event
-        [appleScript executeAppleEvent:containerEvent error:nil];
+        NSDictionary *executionError = nil;
+        [appleScript executeAppleEvent:containerEvent error:&executionError];
+        if (executionError) {
+            NSLog(@"Shuttle AppleScript execution error for %@: %@", scriptPath, executionError);
+        }
     }
 }
 


### PR DESCRIPTION
Only treat command strings as URLs when they have an explicit http/https scheme, since NSURL's parser has become more lenient over time and was misrouting SSH commands to NSWorkspace openURL. Also logs AppleScript execution errors instead of discarding them. Bumps minimum deployment target from 10.9 to 10.13.